### PR TITLE
Provide more information to MPNowPlayingInfoCenter, including album art

### DIFF
--- a/Application/PlaybackController.m
+++ b/Application/PlaybackController.m
@@ -658,6 +658,26 @@ NSDictionary * makeRGInfo(PlaylistEntry *pe)
             [songInfo setObject:[entry artist] forKey:MPMediaItemPropertyArtist];
         if ([entry album])
             [songInfo setObject:[entry album] forKey:MPMediaItemPropertyAlbumTitle];
+        if ([entry albumArt]) {
+            // can't do && with @available
+            if (@available(macOS 10.13.2, *)) {
+                CGSize artworkSize = CGSizeMake(500, 500);
+                MPMediaItemArtwork *mpArtwork = [[MPMediaItemArtwork alloc] initWithBoundsSize:artworkSize requestHandler:^NSImage * _Nonnull(CGSize size) {
+                    return [entry albumArt];
+                }];
+                [songInfo setObject:mpArtwork forKey:MPMediaItemPropertyArtwork];
+            }
+        }
+        // I don't know what NPIC does with these since they aren't exposed in UI, but if we have them, use it.
+        // There's a bunch of other metadata, but PlaylistEntry can't represent a lot of it.
+        if ([entry genre])
+            [songInfo setObject:[entry genre] forKey:MPMediaItemPropertyGenre];
+        if ([entry year]) {
+            // If PlaylistEntry can represent a full date like some tag formats can do, change it
+            NSCalendar *calendar = [NSCalendar currentCalendar];
+            NSDate *releaseYear = [calendar dateWithEra:1 year:[[entry year] intValue] month:0 day:0 hour:0 minute:0 second:0 nanosecond:0];
+            [songInfo setObject:releaseYear forKey:MPMediaItemPropertyReleaseDate];
+        }
         [songInfo setObject:[NSNumber numberWithFloat:[entry currentPosition]] forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
         [songInfo setObject:[entry length] forKey:MPMediaItemPropertyPlaybackDuration];
         [songInfo setObject:[NSNumber numberWithFloat:[entry index]] forKey:MPMediaItemPropertyPersistentID];


### PR DESCRIPTION
NPIC can ask for a lot of metadata, but for now, provide it only what (at least I know) PlaylistEntry can provide. The biggest missing one was album art, so this change should be appreciated by those who do use it.

I don't know what it can do with the other metadata though, seeing at least on macOS, it can only do album/artist/track title/artwork.