### PR TITLE
Send metadata so that NPIC can receive stop events at end of playback

### DIFF
--- a/Application/PlaybackController.m
+++ b/Application/PlaybackController.m
@@ -616,6 +616,8 @@ NSDictionary * makeRGInfo(PlaylistEntry *pe)
     }
 	
 	[self setPlaybackStatus:status];
+    // If we don't send it here, if we've stopped, then the NPIC will be stuck at the last file we played.
+    //[self sendMetaData];
 }
 
 - (void)playlistDidChange:(PlaylistController *)p

--- a/Application/PlaybackController.m
+++ b/Application/PlaybackController.m
@@ -617,7 +617,7 @@ NSDictionary * makeRGInfo(PlaylistEntry *pe)
 	
 	[self setPlaybackStatus:status];
     // If we don't send it here, if we've stopped, then the NPIC will be stuck at the last file we played.
-    //[self sendMetaData];
+    [self sendMetaData];
 }
 
 - (void)playlistDidChange:(PlaylistController *)p


### PR DESCRIPTION
Otherwise, the NPIC will just show the last track stuck at the last second. There may be a better place to put this.

Before:

https://user-images.githubusercontent.com/3161292/127744232-24058a0e-5dc5-402e-86af-34bc210e85f1.mov

After


https://user-images.githubusercontent.com/3161292/127744236-79fb1553-ce30-4cfa-a365-8edd3aa5e85d.mov


