### PR TITLE
[SceneKit Visualization] Refine blocklist again

### DIFF
--- a/Application/MediaKeysApplication.m
+++ b/Application/MediaKeysApplication.m
@@ -20,11 +20,6 @@
 	AppController *_appController;
 }
 
-- (void)reportException:(NSException *)exception {
-	[[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"sceneKitCrashed"];
-	[super reportException:exception];
-}
-
 - (void)finishLaunching {
 	[super finishLaunching];
 	_appController = (AppController *)[self delegate];


### PR DESCRIPTION
This time, refine blocklist to block 10.15.x from even instantiating the SCNView.