### PR TITLE
Adds decimal digits to volume slider tooltip

### DIFF
--- a/Window/VolumeSlider.m
+++ b/Window/VolumeSlider.m
@@ -64,7 +64,15 @@ static void *kVolumeSliderContext = &kVolumeSliderContext;
 	double volume;
 	volume = linearToLogarithmic(value, MAX_VOLUME);
 
-	NSString *text = [NSString stringWithFormat:@"%0.lf%%", volume];
+	// If volume becomes less than 1%, display two decimal digits of precision (e.g. 0.34%).
+	if(volume < 1)
+		NSString *text = [NSString stringWithFormat:@"%0.2lf%%", volume];
+	// Else if volume becomes less than 10%, display one decimal digit of precision (e.g. 3.4%).
+	else if(volume < 10)
+		NSString *text = [NSString stringWithFormat:@"%0.1lf%%", volume];
+	// Else display no decimal digits.
+	else
+		NSString *text = [NSString stringWithFormat:@"%0.lf%%", volume];
 
 	[textView setString:text];
 }

--- a/Window/VolumeSlider.m
+++ b/Window/VolumeSlider.m
@@ -63,16 +63,17 @@ static void *kVolumeSliderContext = &kVolumeSliderContext;
 	double value = [self doubleValue];
 	double volume;
 	volume = linearToLogarithmic(value, MAX_VOLUME);
+	NSString *text;
 
 	// If volume becomes less than 1%, display two decimal digits of precision (e.g. 0.34%).
 	if(volume < 1)
-		NSString *text = [NSString stringWithFormat:@"%0.2lf%%", volume];
+		text = [NSString stringWithFormat:@"%0.2lf%%", volume];
 	// Else if volume becomes less than 10%, display one decimal digit of precision (e.g. 3.4%).
 	else if(volume < 10)
-		NSString *text = [NSString stringWithFormat:@"%0.1lf%%", volume];
+		text = [NSString stringWithFormat:@"%0.1lf%%", volume];
 	// Else display no decimal digits.
 	else
-		NSString *text = [NSString stringWithFormat:@"%0.lf%%", volume];
+		text = [NSString stringWithFormat:@"%0.lf%%", volume];
 
 	[textView setString:text];
 }


### PR DESCRIPTION
Modifies the volume slider tooltip so that:
-If the volume slider falls below 10%, the volume tooltip will display one decimal digit of precision (e.g. 3.4%). 
-Else if the volume slider falls below 1%, display one decimal digit of precision (e.g. 0.34%). 
-Otherwise display the volume slider tooltip as normal.

This helps show changes in volume between 0% and 10% where a change in volume isn't shown in the UI but is heard (especially when the "Limit volume control to 100%" option is unchecked in the "Output" Preferences submenu.