### PR TITLE
Volume slider changes (new branch)

### DIFF
--- a/Audio/Helper.h
+++ b/Audio/Helper.h
@@ -7,5 +7,5 @@
  *
  */
 
-double logarithmicToLinear(double logarithmic, double MAX_VOLUME);
-double linearToLogarithmic(double linear, double MAX_VOLUME);
+double logarithmicToLinear(const double logarithmic, double MAX_VOLUME);
+double linearToLogarithmic(const double linear, double MAX_VOLUME);

--- a/Audio/Helper.m
+++ b/Audio/Helper.m
@@ -13,13 +13,13 @@
 // These functions are helpers for the process of converting volume from a linear to logarithmic scale.
 // Numbers that goes in to audioPlayer should be logarithmic. Numbers that are displayed to the user should be linear.
 // Here's why: http://www.dr-lex.34sp.com/info-stuff/volumecontrols.html
-// We are using the approximation of X^4.
+// We are using the approximation of X^2 when volume is limited to 100% and X^4 when volume is limited to 800%.
 // Input/Output values are in percents.
-double logarithmicToLinear(double logarithmic, double MAX_VOLUME) {
-	return (MAX_VOLUME == 100.0) ? logarithmic : pow((logarithmic / MAX_VOLUME), 0.25) * 100.0;
+double logarithmicToLinear(const double logarithmic, double MAX_VOLUME) {
+	return (MAX_VOLUME == 100.0) ? pow((logarithmic / MAX_VOLUME), 0.5) * 100.0 : pow((logarithmic / MAX_VOLUME), 0.25) * 100.0;
 }
 
-double linearToLogarithmic(double linear, double MAX_VOLUME) {
-	return (MAX_VOLUME == 100.0) ? linear : (linear / 100.0) * (linear / 100.0) * (linear / 100.0) * (linear / 100.0) * MAX_VOLUME;
+double linearToLogarithmic(const double linear, double MAX_VOLUME) {
+	return (MAX_VOLUME == 100.0) ? (linear / 100.0) * (linear / 100.0) * MAX_VOLUME : (linear / 100.0) * (linear / 100.0) * (linear / 100.0) * (linear / 100.0) * MAX_VOLUME;
 }
 // End helper volume function thingies. ONWARDS TO GLORY!

--- a/Window/VolumeSlider.m
+++ b/Window/VolumeSlider.m
@@ -60,9 +60,9 @@ static void *kVolumeSliderContext = &kVolumeSliderContext;
 }
 
 - (void)updateToolTip {
-	double value = [self doubleValue];
-	double volume;
-	volume = linearToLogarithmic(value, MAX_VOLUME);
+	const double value = [self doubleValue];
+	// Sets volume to be the slider value if limit is set to 100% or the actual volume otherwise.
+	const double volume = (MAX_VOLUME == 100) ? value : linearToLogarithmic(value, MAX_VOLUME);
 	NSString *text;
 
 	// If volume becomes less than 1%, display two decimal digits of precision (e.g. 0.34%).


### PR DESCRIPTION
Makes volume slider logarithmic when limited to 100% to allow easier changing of volume towards the bottom of the slider. The tooltip remains as the slider location instead of the logarithmic value of the actual volume.