### PR TITLE
FFmpeg: Fix dsd timeline frames read calculation

### DIFF
--- a/Plugins/FFMPEG/FFMPEGDecoder.m
+++ b/Plugins/FFMPEG/FFMPEGDecoder.m
@@ -1041,7 +1041,6 @@ static void setDictionary(NSMutableDictionary *dict, NSString *tag, NSString *va
 	readNextPacket = YES; // so we immediately read next packet
 	bytesConsumedFromDecodedFrame = INT_MAX; // so we immediately begin decoding next frame
 	framesRead = frame;
-	if(rawDSD) framesRead *= 8;
 	seekFrame = frame + skipSamples;
 	endOfStream = NO;
 	endOfAudio = NO;


### PR DESCRIPTION
This is why I'm here :)

There's a timeline glitch with DSF files when you click on the timeline.

Steps to reproduce:
- Add a `.dsf` (DSD) file to the playlist.
- Start playing it.
- Click the middle of the timeline.
- You'll notice the time displayed exceeds the song's duration, yet the song continues playing from the middle.

Expected behavior:

- The timeline should accurately reflect the current time.


I can't find a reason why we should do `framesRead *= 8` for DSD. Looks like a mistake.