### PR TITLE
Fix lastfm branch build

### DIFF
--- a/Scrobbler/AudioScrobbler.swift
+++ b/Scrobbler/AudioScrobbler.swift
@@ -43,7 +43,7 @@ public class AudioScrobblerTrack: NSObject {
 
 }
 
-public class AudioScrobbler: NSObject {
+public class AudioScrobbler: NSObject, @unchecked Sendable {
 
     let lastFM: LastFMAPI
 


### PR DESCRIPTION
Mark `AudioScrobbler` as `@unchecked Sendable` so the `shared` singleton satisfies strict concurrency checking.

I'm finally working again on this project and will address your PR comments from 8 months ago and add the Settings panel. Thanks for keeping this branch up-to-date with `main`.