### PR TITLE
Improve Move to Trash performance

### DIFF
--- a/Playlist/PlaylistController.h
+++ b/Playlist/PlaylistController.h
@@ -59,6 +59,7 @@ static inline BOOL IsRepeatOneSet(void) {
 
 // Private Methods
 - (void)commitPersistentStore;
+- (void)commitPersistentStoreAsync;
 - (void)updateTotalTime;
 - (void)updatePlaylistIndexes;
 - (IBAction)stopAfterCurrent:(id _Nullable)sender;

--- a/Playlist/PlaylistController.m
+++ b/Playlist/PlaylistController.m
@@ -247,6 +247,16 @@ static void *playlistControllerContext = &playlistControllerContext;
 	}];
 }
 
+- (void)commitPersistentStoreAsync {
+	[self.persistentContainer.viewContext performBlock:^{
+		NSError *error = nil;
+		[self.persistentContainer.viewContext save:&error];
+		if(error) {
+			ALog(@"Error committing playlist storage: %@", [error localizedDescription]);
+		}
+	}];
+}
+
 - (void)updatePlayCountForTrack:(PlaylistEntry *)pe {
 	if(!pe || pe.deLeted || pe.countAdded) return;
 	pe.countAdded = YES;
@@ -1113,19 +1123,61 @@ static void *playlistControllerContext = &playlistControllerContext;
 
 	[super removeObjectsAtArrangedObjectIndexes:indexes];
 
-	[self commitPersistentStore];
-
 	if([self shuffle] != ShuffleOff) [self resetShuffleList];
 
 	[playbackController playlistDidChange:self];
 
+	// Collect file URLs before dispatching to background, since PlaylistEntry
+	// is a CoreData managed object and must not be accessed off its context queue.
+	NSMutableArray<NSDictionary *> *trashWork = [NSMutableArray array];
 	for(PlaylistEntry *pe in objects) {
 		if([pe.url isFileURL]) {
-			NSURL *removed = nil;
-			NSError *error = nil;
-			[[NSFileManager defaultManager] trashItemAtURL:pe.url resultingItemURL:&removed error:&error];
-			pe.trashUrl = removed;
+			[trashWork addObject:@{
+				@"url": pe.url,
+				@"objectID": pe.objectID
+			}];
 		}
+	}
+
+	if([trashWork count] > 0) {
+		NSPersistentContainer *container = self.persistentContainer;
+		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+			NSMutableDictionary<NSManagedObjectID *, NSURL *> *trashedURLs = [NSMutableDictionary dictionary];
+
+			for(NSDictionary *item in trashWork) {
+				NSURL *fileURL = item[@"url"];
+				NSManagedObjectID *objectID = item[@"objectID"];
+				NSURL *removed = nil;
+				NSError *error = nil;
+				[[NSFileManager defaultManager] trashItemAtURL:fileURL resultingItemURL:&removed error:&error];
+				if(removed) {
+					trashedURLs[objectID] = removed;
+				}
+				if(error) {
+					ALog(@"Error trashing file %@: %@", fileURL, [error localizedDescription]);
+				}
+			}
+
+			// Update CoreData on its context queue and persist everything
+			[container.viewContext performBlock:^{
+				for(NSManagedObjectID *objectID in trashedURLs) {
+					NSError *error = nil;
+					PlaylistEntry *pe = (PlaylistEntry *)[container.viewContext existingObjectWithID:objectID error:&error];
+					if(pe && !error) {
+						pe.trashUrl = trashedURLs[objectID];
+					}
+				}
+
+				NSError *saveError = nil;
+				[container.viewContext save:&saveError];
+				if(saveError) {
+					ALog(@"Error saving trash URLs: %@", [saveError localizedDescription]);
+				}
+			}];
+		});
+	} else {
+		// No files to trash, but still need to persist the playlist changes
+		[self commitPersistentStore];
 	}
 }
 
@@ -1558,7 +1610,7 @@ static void *playlistControllerContext = &playlistControllerContext;
 	for(i = 0; i < [shuffleList count]; i++) {
 		[shuffleList[i] setShuffleIndex:i];
 	}
-	[self commitPersistentStore];
+	[self commitPersistentStoreAsync];
 }
 
 - (void)addShuffledListToBack {
@@ -1580,7 +1632,7 @@ static void *playlistControllerContext = &playlistControllerContext;
 	for(i = ([shuffleList count] - [newList count]); i < [shuffleList count]; i++) {
 		[shuffleList[i] setShuffleIndex:(int)i];
 	}
-	[self commitPersistentStore];
+	[self commitPersistentStoreAsync];
 }
 
 - (void)resetShuffleList {
@@ -1615,7 +1667,7 @@ static void *playlistControllerContext = &playlistControllerContext;
 			for(i = 0, j = [shuffleList count]; i < j; ++i) {
 				[shuffleList[i] setShuffleIndex:(int)i];
 			}
-			[self commitPersistentStore];
+			[self commitPersistentStoreAsync];
 		} else {
 			[shuffleList insertObject:currentEntry atIndex:0];
 			[currentEntry setShuffleIndex:0];
@@ -1631,7 +1683,7 @@ static void *playlistControllerContext = &playlistControllerContext;
 					[shuffleList[i] setShuffleIndex:(int)i];
 				}
 			}
-			[self commitPersistentStore];
+			[self commitPersistentStoreAsync];
 		}
 	}
 }


### PR DESCRIPTION
## Problem

When using Cog with a large playlist and trashing songs via "Move to Trash"  the UI freezes noticeably, anywhere from a few hundred milliseconds to several seconds depending on playlist size and whether App Sandbox is enabled. This makes the workflow of listening through a playlist and trashing unwanted songs feel sluggish.

## Root Cause

The `trashObjectsAtArrangedObjectIndexes:` method in `PlaylistController.m` was doing all of its work synchronously on the main thread:

1. **`NSFileManager trashItemAtURL:`** — the actual file move to Trash, which is especially slow under App Sandbox due to security framework coordination
2. **`commitPersistentStore`** — a synchronous CoreData save (`performBlockAndWait:`) after removing entries from the playlist
3. **Shuffle reset** — `resetShuffleList` → `addShuffledListToFront`, each containing their own synchronous `commitPersistentStore` calls

With shuffle enabled, a single trash operation could trigger **3 synchronous CoreData saves** plus the file I/O, all blocking the UI.

## Changes

- **Move file trash operations to a background queue** — `trashItemAtURL:` calls are dispatched via `dispatch_async`. File URLs and CoreData `objectID`s are captured on the main thread first (since `PlaylistEntry` is a managed object), then the file operations run in the background. After completion, `trashUrl` is updated on the CoreData context queue via `performBlock:`.
- **Add `commitPersistentStoreAsync`** — a new method using `performBlock:` (non-blocking) instead of `performBlockAndWait:` (blocking).
- **Switch shuffle methods to async saves** — `addShuffledListToFront`, `addShuffledListToBack`, and `resetShuffleList` now use `commitPersistentStoreAsync`. These methods only persist shuffle indexes, which are regenerated on app launch anyway, so there's no durability concern.
- **Remove redundant synchronous save** from the trash path — the background block handles persistence after the file operations complete.

## Benchmarks

Measured on a playlist with ~2000 entries, trashing 1 entry at a time (Debug build, shuffle enabled):

### Before (all synchronous on main thread)
```
TOTAL: 0.270s | UI removal: 0.085s | CoreData save: 0.000s | Shuffle reset: 0.175s | File trash: 0.011s
TOTAL: 0.200s | UI removal: 0.108s | CoreData save: 0.000s | Shuffle reset: 0.089s | File trash: 0.002s
TOTAL: 0.161s | UI removal: 0.090s | CoreData save: 0.000s | Shuffle reset: 0.069s | File trash: 0.002s
```

### After (file trash + CoreData saves async)
```
TOTAL: 0.117s | UI removal: 0.111s | Shuffle reset: 0.005s | File trash: async
TOTAL: 0.109s | UI removal: 0.104s | Shuffle reset: 0.005s | File trash: async
TOTAL: 0.117s | UI removal: 0.111s | Shuffle reset: 0.006s | File trash: async
TOTAL: 0.064s | UI removal: 0.059s | Shuffle reset: 0.005s | File trash: async
```

These improvements scale further with larger playlists and under App Sandbox, where the file trash and CoreData save costs are significantly higher.


---
I'm not sure what your policy is regarding clanker PRs but I used Claude to identify and fix the issue after experiencing it myself. Let me know if what needs to be changed and I will revise my PR. :) 
