### PR TITLE
Correct vertical alignment for track TimeField in the toolbar

### DIFF
--- a/Window/TimeField.m
+++ b/Window/TimeField.m
@@ -18,17 +18,15 @@ NSString *formatTimer(long minutes, long seconds, unichar prefix, int padding) {
 
 @implementation TimeField {
 	BOOL showTimeRemaining;
-	NSDictionary *fontAttributes;
 }
 
 - (void)awakeFromNib {
 	CGFloat fontSize = 13.0;
 
 	showTimeRemaining = [[NSUserDefaults standardUserDefaults] boolForKey:kTimerModeKey];
-
-	NSFont *font = [NSFont monospacedDigitSystemFontOfSize:fontSize weight:NSFontWeightRegular];
-
-	fontAttributes = @{ NSFontAttributeName: font };
+    
+    self.font = [NSFont monospacedDigitSystemFontOfSize:fontSize
+                                                 weight:NSFontWeightRegular];
 
 	[self update];
 }
@@ -59,9 +57,7 @@ static int _log10(long minutes) {
 		int padding = MAX(0, otherminutedigits - minutedigits);
 		text = formatTimer(sec / 60, sec % 60, 0x2212, padding); // Minus
 	}
-	NSAttributedString *string = [[NSAttributedString alloc] initWithString:text
-	                                                             attributes:fontAttributes];
-	[self setAttributedStringValue:string];
+    [self setStringValue:text];
 }
 
 - (void)mouseDown:(NSEvent *)theEvent {

--- a/Window/TimeField.m
+++ b/Window/TimeField.m
@@ -25,8 +25,8 @@ NSString *formatTimer(long minutes, long seconds, unichar prefix, int padding) {
 
 	showTimeRemaining = [[NSUserDefaults standardUserDefaults] boolForKey:kTimerModeKey];
     
-    self.font = [NSFont monospacedDigitSystemFontOfSize:fontSize
-                                                 weight:NSFontWeightRegular];
+	self.font = [NSFont monospacedDigitSystemFontOfSize:fontSize
+	                                             weight:NSFontWeightRegular];
 
 	[self update];
 }
@@ -57,7 +57,7 @@ static int _log10(long minutes) {
 		int padding = MAX(0, otherminutedigits - minutedigits);
 		text = formatTimer(sec / 60, sec % 60, 0x2212, padding); // Minus
 	}
-    [self setStringValue:text];
+	[self setStringValue:text];
 }
 
 - (void)mouseDown:(NSEvent *)theEvent {


### PR DESCRIPTION
# Summary

Fixes the vertical alignment of the current playback time in the macOS toolbar.

The time field now uses its own monospaced-digit font together with `stringValue`, allowing AppKit to apply consistent font metrics for both layout and rendering. This removes the previous attributed-string font path that caused the text to appear slightly too high.