### PR TITLE
Improve live stream pause responsiveness

### DIFF
--- a/Audio/Chain/InputNode.m
+++ b/Audio/Chain/InputNode.m
@@ -191,6 +191,9 @@ static void *kInputNodeContext = &kInputNodeContext;
 		@autoreleasepool {
 			chunk = [decoder readAudio];
 		}
+		if([self shouldContinue] == NO) {
+			break;
+		}
 
 		if(chunk && [chunk frameCount]) {
 			@autoreleasepool {
@@ -202,6 +205,9 @@ static void *kInputNodeContext = &kInputNodeContext;
 				chunk = nil;
 			}
 		} else {
+			if([self shouldContinue] == NO) {
+				break;
+			}
 			if(chunk) {
 				@autoreleasepool {
 					chunk = nil;
@@ -274,8 +280,12 @@ static void *kInputNodeContext = &kInputNodeContext;
 
 - (void)setShouldContinue:(BOOL)s {
 	[super setShouldContinue:s];
-	if(!s)
+	if(!s) {
 		[self removeObservers];
+		if([decoder respondsToSelector:@selector(interrupt)]) {
+			[decoder interrupt];
+		}
+	}
 }
 
 - (void)setResetBuffers:(BOOL)resetBuffers {

--- a/Audio/Plugin.h
+++ b/Audio/Plugin.h
@@ -19,6 +19,11 @@
 - (long)read:(void *)buffer amount:(long)amount; // reads UP TO amount, returns amount read.
 - (void)close;
 - (void)dealloc;
+
+@optional
+// Promptly unblock any in-flight read without waiting for full teardown.
+// The normal -close call still follows on the reader's own thread.
+- (void)interrupt;
 @end
 
 @protocol CogVersionCheck <NSObject>
@@ -56,6 +61,10 @@
 
 @optional
 - (void)dealloc;
+
+// Promptly unblock -readAudio when playback is being stopped. Implementations
+// should only interrupt their input here; decoder teardown remains in -close.
+- (void)interrupt;
 
 - (BOOL)setTrack:(NSURL *)track;
 

--- a/Plugins/FFMPEG/FFMPEGDecoder.m
+++ b/Plugins/FFMPEG/FFMPEGDecoder.m
@@ -557,6 +557,12 @@ static uint8_t reverse_bits[0x100];
 	}
 }
 
+- (void)interrupt {
+	if([source respondsToSelector:@selector(interrupt)]) {
+		[source interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }

--- a/Plugins/Flac/FlacDecoder.m
+++ b/Plugins/Flac/FlacDecoder.m
@@ -468,6 +468,12 @@ void ErrorCallback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorS
 	blockBuffer = NULL;
 }
 
+- (void)interrupt {
+	if([source respondsToSelector:@selector(interrupt)]) {
+		[source interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }

--- a/Plugins/HLS/HLSDecoder.m
+++ b/Plugins/HLS/HLSDecoder.m
@@ -252,6 +252,14 @@ static void *kHLSDecoderContext = &kHLSDecoderContext;
 	[stateLock unlock];
 }
 
+- (void)interrupt {
+	[segmentManager interrupt];
+	[memorySource interrupt];
+	if([decoder respondsToSelector:@selector(interrupt)]) {
+		[decoder interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }

--- a/Plugins/HLS/HLSMemorySource.m
+++ b/Plugins/HLS/HLSMemorySource.m
@@ -193,4 +193,8 @@
 	[_cond unlock];
 }
 
+- (void)interrupt {
+	[self close];
+}
+
 @end

--- a/Plugins/HLS/HLSSegmentManager.h
+++ b/Plugins/HLS/HLSSegmentManager.h
@@ -59,6 +59,10 @@
 // the last synchronously-downloaded index + 1).
 - (void)startFetchingFromIndex:(NSInteger)index;
 
+// Request cancellation and interrupt active HTTP reads without waiting for the
+// fetch thread to exit. Safe to call from a playback-control thread.
+- (void)interrupt;
+
 // Stop the background fetcher. Blocks until the thread exits.
 - (void)stop;
 

--- a/Plugins/HLS/HLSSegmentManager.m
+++ b/Plugins/HLS/HLSSegmentManager.m
@@ -41,6 +41,7 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 	NSInteger _nextFetchIndex;          // next index into playlist.segments to fetch
 	BOOL _stopRequested;
 	BOOL _running;
+	NSMutableSet<id<CogSource>> *_activeSources;
 
 	// Live-stream playlist refresh:
 	NSDate *_lastRefreshDate;
@@ -59,6 +60,7 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 		_nextFetchIndex = 0;
 		_stopRequested = NO;
 		_running = NO;
+		_activeSources = [NSMutableSet set];
 		_seenSequenceNumbers = [NSMutableSet set];
 		for(HLSSegment *seg in playlist.segments) {
 			[_seenSequenceNumbers addObject:@(seg.sequenceNumber)];
@@ -110,12 +112,35 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 
 	Class audioSourceClass = NSClassFromString(@"AudioSource");
 	id<CogSource> src = [audioSourceClass audioSourceForURL:segment.url];
-	if(!src || ![src open:segment.url]) {
+	if(!src) {
 		if(error) {
 			*error = [NSError errorWithDomain:@"HLSSegmentManager"
 			                             code:3
 			                         userInfo:@{NSLocalizedDescriptionKey:
 			    [NSString stringWithFormat:@"Failed to open segment: %@", segment.url]}];
+		}
+		return nil;
+	}
+
+	[_cond lock];
+	BOOL cancelled = _stopRequested;
+	if(!cancelled) {
+		[_activeSources addObject:src];
+	}
+	[_cond unlock];
+
+	if(cancelled || ![src open:segment.url]) {
+		if(error) {
+			*error = [NSError errorWithDomain:@"HLSSegmentManager"
+			                             code:cancelled ? NSUserCancelledError : 3
+			                         userInfo:@{NSLocalizedDescriptionKey:
+			    cancelled ? @"Segment download cancelled" :
+			                [NSString stringWithFormat:@"Failed to open segment: %@", segment.url]}];
+		}
+		if(!cancelled) {
+			[_cond lock];
+			[_activeSources removeObject:src];
+			[_cond unlock];
 		}
 		return nil;
 	}
@@ -133,6 +158,19 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 		[data appendBytes:buf length:got];
 	}
 	[src close];
+	[_cond lock];
+	[_activeSources removeObject:src];
+	cancelled = _stopRequested;
+	[_cond unlock];
+
+	if(cancelled) {
+		if(error) {
+			*error = [NSError errorWithDomain:@"HLSSegmentManager"
+			                             code:NSUserCancelledError
+			                         userInfo:@{NSLocalizedDescriptionKey: @"Segment download cancelled"}];
+		}
+		return nil;
+	}
 
 	if([data length] == 0) {
 		if(error) {
@@ -169,16 +207,15 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 }
 
 - (void)stop {
+	[self interrupt];
+
 	[_cond lock];
-	_stopRequested = YES;
-	[_cond broadcast];
 	NSThread *t = _fetchThread;
 	[_cond unlock];
 
 	// Wait for the thread to exit. NSThread doesn't have a direct join,
-	// so spin on the `executing`/`finished` flags. The fetch loop
-	// checks _stopRequested on every iteration, so this only takes one
-	// in-flight HTTP request to drain in the worst case.
+	// so spin on the `executing`/`finished` flags. Active HTTP reads have
+	// already been interrupted, so this no longer waits for network I/O.
 	if(t && t != [NSThread currentThread]) {
 		while(!t.finished) {
 			[NSThread sleepForTimeInterval:0.01];
@@ -189,6 +226,22 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 	_running = NO;
 	_fetchThread = nil;
 	[_cond unlock];
+}
+
+- (void)interrupt {
+	[_cond lock];
+	_stopRequested = YES;
+	NSArray<id<CogSource>> *sources = [_activeSources allObjects];
+	[_cond broadcast];
+	[_cond unlock];
+
+	for(id<CogSource> src in sources) {
+		if([src respondsToSelector:@selector(interrupt)]) {
+			[src interrupt];
+		} else {
+			[src close];
+		}
+	}
 }
 
 #pragma mark - Background fetch loop
@@ -231,6 +284,10 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 						_consecutiveFailures = 0;
 						didWork = YES;
 					} else {
+						[_cond lock];
+						BOOL stopping = _stopRequested;
+						[_cond unlock];
+						if(stopping) break;
 						ALog(@"HLS: segment fetch failed (%@): %@",
 						     next.url, fetchErr.localizedDescription);
 						[self handleFetchFailure];
@@ -267,14 +324,36 @@ static const NSInteger kMaxConsecutiveFailures = 5;
 
 	Class audioSourceClass = NSClassFromString(@"AudioSource");
 	id<CogSource> src = [audioSourceClass audioSourceForURL:self.playlist.url];
-	if(!src || ![src open:self.playlist.url]) {
+	if(!src) {
 		ALog(@"HLS: failed to reopen playlist for refresh: %@", self.playlist.url);
+		return;
+	}
+
+	[_cond lock];
+	BOOL cancelled = _stopRequested;
+	if(!cancelled) {
+		[_activeSources addObject:src];
+	}
+	[_cond unlock];
+
+	if(cancelled || ![src open:self.playlist.url]) {
+		if(!cancelled) {
+			[_cond lock];
+			[_activeSources removeObject:src];
+			[_cond unlock];
+			ALog(@"HLS: failed to reopen playlist for refresh: %@", self.playlist.url);
+		}
 		return;
 	}
 
 	NSError *parseErr = nil;
 	HLSPlaylist *fresh = [HLSPlaylistParser parsePlaylistFromSource:src error:&parseErr];
 	[src close];
+	[_cond lock];
+	[_activeSources removeObject:src];
+	cancelled = _stopRequested;
+	[_cond unlock];
+	if(cancelled) return;
 
 	if(!fresh) {
 		ALog(@"HLS: playlist refresh failed to parse: %@", parseErr.localizedDescription);

--- a/Plugins/HTTPSource/HTTPSource.m
+++ b/Plugins/HTTPSource/HTTPSource.m
@@ -16,6 +16,10 @@
 #import <stdlib.h>
 #import <string.h>
 
+@interface HTTPSource ()
+@property(atomic) BOOL interruptRequested;
+@end
+
 @implementation HTTPSource
 
 static size_t http_data_write_wrapper(HTTPSource *fp, char *ptr, size_t size) {
@@ -451,8 +455,16 @@ static void http_stream_reset(HTTPSource *fp) {
 		// Create session with self as delegate
 		session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:delegateQueue];
 
+		[mutex lock];
 		length = -1;
+		if(need_abort) {
+			self->status = STATUS_ABORTED;
+			[mutex unlock];
+			[session invalidateAndCancel];
+			return;
+		}
 		self->status = STATUS_INITIAL;
+		[mutex unlock];
 
 		DLog(@"urlsession: started loading data %@", URL);
 
@@ -706,6 +718,11 @@ static void http_stream_reset(HTTPSource *fp) {
 	metadata_have_size = 0;
 
 	need_abort = NO;
+	if(self.interruptRequested) {
+		need_abort = YES;
+		status = STATUS_ABORTED;
+		return NO;
+	}
 
 	album = @"";
 	artist = @"";
@@ -728,6 +745,7 @@ static void http_stream_reset(HTTPSource *fp) {
 	// Now wait for it to either begin streaming, or complete if file is small enough to fit in the buffer
 	while(status != STATUS_READING &&
 	      status != STATUS_FINISHED &&
+	      status != STATUS_ABORTED &&
 	      !dataTask) {
 		usleep(3000);
 	}
@@ -911,6 +929,19 @@ static void http_stream_reset(HTTPSource *fp) {
 
 + (NSArray *)schemes {
 	return @[@"http", @"https"];
+}
+
+- (void)interrupt {
+	self.interruptRequested = YES;
+
+	[mutex lock];
+	need_abort = YES;
+	content_type = nil;
+	status = STATUS_ABORTED;
+	NSURLSessionDataTask *task = dataTask;
+	[mutex unlock];
+
+	[task cancel];
 }
 
 @end

--- a/Plugins/Opus/Opus/OpusDecoder.m
+++ b/Plugins/Opus/Opus/OpusDecoder.m
@@ -309,6 +309,12 @@ static void setDictionary(NSMutableDictionary *dict, NSString *tag, NSString *va
 	opusRef = NULL;
 }
 
+- (void)interrupt {
+	if([source respondsToSelector:@selector(interrupt)]) {
+		[source interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }

--- a/Plugins/Vorbis/VorbisDecoder.m
+++ b/Plugins/Vorbis/VorbisDecoder.m
@@ -274,6 +274,12 @@ static void setDictionary(NSMutableDictionary *dict, NSString *tag, NSString *va
 	ov_clear(&vorbisRef);
 }
 
+- (void)interrupt {
+	if([source respondsToSelector:@selector(interrupt)]) {
+		[source interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }

--- a/Plugins/minimp3/MP3Decoder.m
+++ b/Plugins/minimp3/MP3Decoder.m
@@ -305,6 +305,12 @@ static int mp3_seek_callback(uint64_t position, void *user_data) {
 	}
 }
 
+- (void)interrupt {
+	if([_source respondsToSelector:@selector(interrupt)]) {
+		[_source interrupt];
+	}
+}
+
 - (long)seek:(long)frame {
 	if(frame == _framesDecoded) {
 		return frame;


### PR DESCRIPTION
## Summary

Improve live stream pause responsiveness by interrupting blocked network reads during playback teardown.

## Changes

- Add cooperative interruption support for audio sources and decoders.
- Cancel active HTTP and HLS requests when playback stops.
- Forward interruption through FFmpeg, MP3, FLAC, Vorbis, and Opus decoders.
- Prevent interrupted reads from being treated as a natural end of stream.
- Preserve the existing stop/reconnect behavior for non-seekable live streams.