### PR TITLE
Forward interrupts through decoder wrappers

### DIFF
--- a/Audio/CogPluginMulti.m
+++ b/Audio/CogPluginMulti.m
@@ -112,6 +112,13 @@ static void *kCogDecoderMultiContext = &kCogDecoderMultiContext;
 	}
 }
 
+- (void)interrupt {
+	id<CogDecoder> activeDecoder = theDecoder;
+	if([activeDecoder respondsToSelector:@selector(interrupt)]) {
+		[activeDecoder interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }

--- a/Plugins/CueSheet/CueSheetDecoder.m
+++ b/Plugins/CueSheet/CueSheetDecoder.m
@@ -267,6 +267,19 @@ static void *kCueSheetDecoderContext = &kCueSheetDecoderContext;
 	track = nil;
 }
 
+- (void)interrupt {
+	id<CogDecoder> activeDecoder = decoder;
+	if([activeDecoder respondsToSelector:@selector(interrupt)]) {
+		[activeDecoder interrupt];
+		return;
+	}
+
+	id<CogSource> activeSource = source;
+	if([activeSource respondsToSelector:@selector(interrupt)]) {
+		[activeSource interrupt];
+	}
+}
+
 - (void)dealloc {
 	[self close];
 }


### PR DESCRIPTION
## Summary

Forward decoder interruption requests through Cog’s wrapper decoder layers so blocked network reads can be cancelled promptly during playback teardown.

## Problem

`InputNode` sends `interrupt` to its active decoder when playback is stopped. For common formats, however, the concrete decoder is often wrapped by `CogDecoderMulti` and `CueSheetDecoder`.

Neither wrapper forwarded `interrupt`, so requests could stop before reaching implementations such as FFMPEG, FLAC, MP3, Opus, Vorbis, HLS, or their HTTP sources. Playback teardown could consequently wait for an outstanding network read to time out.

## Changes

- Add `interrupt` forwarding from `CogDecoderMulti` to its selected decoder.
- Add `interrupt` forwarding from `CueSheetDecoder` to its underlying decoder.
- Fall back to interrupting the CUE source directly when its decoder does not implement interruption.
- Capture active decoder/source references locally to keep interruption safe during concurrent teardown.

## Result

The interruption chain now reaches the concrete decoder and source:

```text
InputNode
  → CogDecoderMulti
    → CueSheetDecoder
      → concrete decoder
        → HTTP/HLS source
```

This allows stalled network reads to unblock promptly without changing normal decoding, seeking, CUE handling, or decoder cleanup.

## Validation

- Full Debug macOS build succeeded.
- `git diff --check` passed.
- No new build warnings related to these changes.