### PR TITLE
Preload metadata for embedded CUE tracks

### DIFF
--- a/Playlist/PlaylistLoader.m
+++ b/Playlist/PlaylistLoader.m
@@ -293,10 +293,45 @@ static inline void dispatch_sync_reentrant(dispatch_queue_t queue, dispatch_bloc
 	}
 }
 
+static inline BOOL cueSheetValueHasContent(id value) {
+	if([value isKindOfClass:[NSString class]]) {
+		return [value length] > 0;
+	}
+	if([value isKindOfClass:[NSArray class]]) {
+		for(id item in value) {
+			if([item isKindOfClass:[NSString class]] && [item length] > 0) {
+				return YES;
+			}
+		}
+	}
+	return NO;
+}
+
 static inline BOOL isCueSheetTrackURL(NSURL *url) {
-	return [url isFileURL] &&
-	       [[url fragment] length] &&
-	       [[url pathExtension] caseInsensitiveCompare:@"cue"] == NSOrderedSame;
+	if(![url isFileURL] || ![[url fragment] length]) {
+		return NO;
+	}
+	if([[url pathExtension] caseInsensitiveCompare:@"cue"] == NSOrderedSame) {
+		return YES;
+	}
+
+	// Embedded CUE tracks retain the audio file's extension (for example,
+	// album.flac#01). Inspect the underlying file without its track fragment;
+	// checking the fragment alone would also match unrelated subsong URLs.
+	NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+	components.fragment = nil;
+	NSURL *baseURL = components.URL;
+	if(!baseURL) {
+		return NO;
+	}
+
+	NSDictionary *metadata = [AudioMetadataReader metadataForURL:baseURL skipCue:YES];
+	if(cueSheetValueHasContent(metadata[@"cuesheet"])) {
+		return YES;
+	}
+
+	NSDictionary *properties = [AudioPropertiesReader propertiesForURL:baseURL skipCue:YES];
+	return cueSheetValueHasContent(properties[@"cuesheet"]);
 }
 
 - (void)beginProgress:(NSString *)localizedDescription {


### PR DESCRIPTION
## Summary

This PR extends playlist metadata preloading to tracks generated from embedded CUE sheets.

Embedded CUE tracks retain the underlying audio file extension, such as `album.flac#01`. Previously, only external CUE URLs such as `album.cue#01` were recognized, which could cause embedded-CUE rows to briefly display incomplete or raw metadata.

## Implementation

- Recognizes external `.cue` track URLs as before.
- For other fragmented file URLs, inspects the fragment-free source file for embedded CUE metadata.
- Checks both metadata and audio properties for a non-empty CUE sheet.
- Avoids treating every fragmented URL as a CUE track, preserving correct behavior for unrelated multi-subsong formats.

## Test plan

- Confirm embedded-CUE tracks display their metadata immediately when inserted.
- Confirm external CUE sheets continue to preload correctly.
- Confirm non-CUE subsong URLs are not misclassified.
- Build Cog in the macOS Debug configuration.

The full macOS Debug build passes.