### PR TITLE
Remote control: add_to_playlist no longer deadlocks the main thread

### DIFF
--- a/CogRemoteControl/RemoteControlToolHandlers.swift
+++ b/CogRemoteControl/RemoteControlToolHandlers.swift
@@ -230,7 +230,7 @@ enum RemoteControlTools {
 				throw MCPError.invalidParams("urls must be a non-empty array of strings")
 			}
 			let count = target.remoteAdd(toPlaylist: urls)
-			return text("Added \(count) entr\(count == 1 ? "y" : "ies") to the playlist.")
+			return text("Queued \(count) entr\(count == 1 ? "y" : "ies") for adding to the playlist.")
 
 		case "remove_from_playlist":
 			guard let index = arguments["index"]?.intValue else {

--- a/RemoteControl/CogRemoteControlAdapter.swift
+++ b/RemoteControl/CogRemoteControlAdapter.swift
@@ -194,7 +194,7 @@ import Cocoa
 	}
 
 	func remoteAdd(toPlaylist urls: [String]) -> Int {
-		guard let loader = appController?.playlistLoader else { return 0 }
+		guard let playlist else { return 0 }
 
 		let parsed = urls.compactMap { string -> URL? in
 			if string.contains("://") {
@@ -204,7 +204,18 @@ import Cocoa
 		}
 		guard !parsed.isEmpty else { return 0 }
 
-		return loader.addURLs(parsed, sort: false)?.count ?? 0
+		// PlaylistLoader blocks on its metadata operations, and those report
+		// progress back to the main thread with dispatch_sync; loading from
+		// the main actor would deadlock. Use the same background path as the
+		// app's own open handlers (see AppController's addURLsInBackground
+		// call sites).
+		let loadEntryData: [String: Any] = [
+			"entries": parsed,
+			"sort": false,
+			"origin": URLOrigin.external.rawValue,
+		]
+		playlist.performSelector(inBackground: #selector(PlaylistController.addURLs(inBackground:)), with: loadEntryData)
+		return parsed.count
 	}
 
 	func remoteRemoveFromPlaylist(at index: Int) -> Bool {


### PR DESCRIPTION
## Summary

The MCP `add_to_playlist` tool deadlocks Cog's main thread. Audio keeps playing, but the UI beachballs, Apple Events stop being handled (even `quit` hangs), and every subsequent MCP request times out until the app is force-killed.

## Root cause

All MCP tool calls are dispatched on the main actor (`RemoteControlToolHandlers.call` runs `MainActor.run`), and `CogRemoteControlAdapter.remoteAdd(toPlaylist:)` called `PlaylistLoader.addURLs()` synchronously from there.

`PlaylistLoader` is designed to run off the main thread: `insertURLs` blocks in `[queue waitUntilAllOperationsAreFinished]` while its container/metadata `NSOperation`s report progress via `dispatch_sync_reentrant(dispatch_get_main_queue(), …)`. When the caller *is* the main thread, the operations block waiting for the main queue and the main thread blocks waiting for the operations — a classic AB/BA deadlock. The app's own open handlers avoid it by always going through `performSelectorInBackground:@selector(addURLsInBackground:)` (see `AppController.m`).

Sampled stack from a hung instance (build 3610, macOS 26.5.2):

```
1929 Thread_7366893  DispatchQueue_1: com.apple.main-thread (serial)
+ 1929 completeTaskWithClosure(...)  (libswift_Concurrency)
+   1929 ??? (CogRemoteControl) ...
+     1929 ??? (Cog) ...
+       1929 -[NSOperationQueue waitUntilAllOperationsAreFinished] (Foundation)
+         1929 __NSOPERATIONQUEUE_IS_WAITING_ON_AN_OPERATION__ (Foundation)
+           1929 -[NSOperation waitUntilFinished] (Foundation)
+             1929 _pthread_cond_wait
```

## Fix

Route the remote add through the same `addURLsInBackground:` background path the app's open handlers use, and report the queued URL count instead of a synchronous added count (the tool description already documents that unplayable paths are accepted).

## Repro

1. Connect any MCP client to cog-mcp.
2. Call `add_to_playlist` with a local file path.
3. Main thread deadlocks (sample shows the stack above); audio continues, UI and MCP are dead.

## Testing

Built the branch with the repo's `debug.yml` workflow and ran an MCP stdio regression client against the debug build:

- `add_to_playlist` with a local FLAC returns immediately (`Queued 1 entry for adding to the playlist.`) instead of deadlocking.
- `now_playing` issued right after responds — the main thread stays live.
- `list_playlist` a few seconds later shows the track added with full metadata, confirming the background load completes.

Before the patch, the same call wedged the app permanently (stack above).

Happy to adjust if the queued-count wording should stay as "Added".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
