### PR TITLE
Fix/cue playback failure handling

### DIFF
--- a/Audio/AudioPlayer.h
+++ b/Audio/AudioPlayer.h
@@ -122,6 +122,7 @@
 - (void)endOfInputPlayed;
 - (void)reportPlayCount;
 - (void)reportScrobble;
+- (void)setError:(BOOL)status forTrack:(id)userInfo;
 - (void)sendDelegateMethod:(SEL)selector withVoid:(void *)obj waitUntilDone:(BOOL)wait;
 - (void)sendDelegateMethod:(SEL)selector withObject:(id)obj waitUntilDone:(BOOL)wait;
 - (void)sendDelegateMethod:(SEL)selector withObject:(id)obj withObject:(id)obj2 waitUntilDone:(BOOL)wait;

--- a/Audio/AudioPlayer.m
+++ b/Audio/AudioPlayer.m
@@ -15,6 +15,25 @@
 
 #import "Logging.h"
 
+static NSURL *streamURLWithoutFragment(NSURL *url) {
+	if(!url || ![[url fragment] length]) {
+		return url;
+	}
+
+	NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+	components.fragment = nil;
+	return components.URL;
+}
+
+static BOOL streamURLsShareUnderlyingResource(NSURL *firstURL, NSURL *secondURL) {
+	NSURL *firstResource = streamURLWithoutFragment(firstURL);
+	NSURL *secondResource = streamURLWithoutFragment(secondURL);
+	if(!firstResource || !secondResource) {
+		return NO;
+	}
+	return [firstResource isEqualTo:secondResource];
+}
+
 @implementation AudioPlayer {
 	BOOL stoppedRecently;
 }
@@ -106,7 +125,23 @@
 		[self notifyStreamChanged:userInfo];
 	}
 
-	while(![bufferChain open:url withOutputFormat:[output format] withUserInfo:userInfo withRGInfo:rgi resetBuffers:YES]) {
+	NSURL *failedFragmentResource = nil;
+	BOOL advancedPastFailedStream = NO;
+	while(YES) {
+		BOOL skipRepeatedProbe = failedFragmentResource && streamURLsShareUnderlyingResource(failedFragmentResource, url);
+		if(!skipRepeatedProbe && [bufferChain open:url withOutputFormat:[output format] withUserInfo:userInfo withRGInfo:rgi resetBuffers:YES]) {
+			break;
+		}
+
+		if(skipRepeatedProbe) {
+			DLog(@"Skipping another logical track from failed source: %@", url);
+		} else {
+			// Logical tracks with different fragments share one decoder source. If
+			// that source cannot be opened, probing every remaining fragment repeats
+			// the same expensive failure while this method blocks the main thread.
+			failedFragmentResource = [[url fragment] length] ? streamURLWithoutFragment(url) : nil;
+		}
+		[self setError:YES forTrack:userInfo];
 		bufferChain = nil;
 
 		[self requestNextStream:userInfo];
@@ -122,10 +157,14 @@
 
 		userInfo = nextStreamUserInfo;
 		rgi = nextStreamRGInfo;
-
-		[self notifyStreamChanged:userInfo];
+		advancedPastFailedStream = YES;
 
 		bufferChain = [[BufferChain alloc] initWithController:self];
+	}
+	if(advancedPastFailedStream) {
+		// Do not present every failed fallback as the current track. Publish only
+		// the first stream that actually opened.
+		[self notifyStreamChanged:userInfo];
 	}
 
 	if(resumeInterval || time > 0.0) {

--- a/Audio/AudioPlayer.m
+++ b/Audio/AudioPlayer.m
@@ -686,8 +686,11 @@
 //	[self sendDelegateMethod:@selector(audioPlayer:sustainHDCD:) withObject:[bufferChain userInfo] waitUntilDone:NO];
 }
 
-- (void)setError:(BOOL)status {
-	[self sendDelegateMethod:@selector(audioPlayer:setError:toTrack:) withObject:@(status) withObject:[bufferChain userInfo] waitUntilDone:NO];
+- (void)setError:(BOOL)status forTrack:(id)userInfo {
+	// Buffer chains overlap while tracks are preloaded and switched. Preserve
+	// the chain's own track here; consulting the current global bufferChain when
+	// this asynchronous callback runs can apply a late error to the next track.
+	[self sendDelegateMethod:@selector(audioPlayer:setError:toTrack:) withObject:@(status) withObject:userInfo waitUntilDone:NO];
 }
 
 - (void)setPlaybackStatus:(int)status {

--- a/Audio/Chain/BufferChain.m
+++ b/Audio/Chain/BufferChain.m
@@ -314,7 +314,8 @@
 }
 
 - (void)setError:(BOOL)status {
-	[controller setError:status];
+	AudioPlayer *audioPlayer = controller;
+	[audioPlayer setError:status forTrack:userInfo];
 }
 
 @end

--- a/Audio/Chain/InputNode.m
+++ b/Audio/Chain/InputNode.m
@@ -204,13 +204,10 @@ static void *kInputNodeContext = &kInputNodeContext;
 			DLog(@"Seeked! Resetting Buffer");
 			initialBufferFilled = NO;
 
-			if(seekError) {
-				[controller setError:YES];
-			}
-
 			signalReset = YES;
 
 			if([self hasSeekRequestAfterID:activeSeekRequestID]) {
+				seekError = NO;
 				continue;
 			}
 		}
@@ -229,6 +226,11 @@ static void *kInputNodeContext = &kInputNodeContext;
 		}
 
 		if(chunk && [chunk frameCount]) {
+			// Some decoders can recover from an inexact or rejected seek and
+			// immediately return valid audio (cue-sheet fragments do this by
+			// seeking to their own start). Do not persist a track error when the
+			// requested playback is still producing audio.
+			seekError = NO;
 			@autoreleasepool {
 				if(signalReset) {
 					chunk.resetForward = YES;
@@ -240,6 +242,11 @@ static void *kInputNodeContext = &kInputNodeContext;
 		} else {
 			if([self shouldContinue] == NO) {
 				break;
+			}
+			if(seekError) {
+				ALog(@"Decoder seek failed and produced no audio");
+				[controller setError:YES];
+				seekError = NO;
 			}
 			if(chunk) {
 				@autoreleasepool {


### PR DESCRIPTION
## Summary

Improve failure handling for CUE and other multi-track sources so recoverable decoder behavior does not produce false track errors, while genuinely failed sources are skipped efficiently.

## Changes

- Associate playback errors with the buffer chain’s originating track instead of whichever track is current when an asynchronous callback arrives.
- Ignore superseded seek failures and clear recoverable seek errors when the decoder subsequently produces valid audio.
- Treat fragment URLs as logical tracks backed by the same underlying resource.
- After an underlying resource fails to open, skip repeated decoder probes for its remaining logical tracks.
- Mark skipped tracks appropriately while searching for the next playable source.
- Publish a stream-change notification only after a fallback stream opens successfully.

## Result

CUE tracks that recover from an imperfect seek are no longer incorrectly marked as failed. When a shared multi-track source genuinely cannot be opened, Cog avoids repeating the same expensive probe for every track and advances to the next playable source without presenting failed fallbacks as the current track.

## Verification

- Both commits build successfully in Debug for arm64 with code signing disabled.
- `git diff --check main...fix/cue-playback-failure-handling` passes.

## Suggested manual checks

- Play a valid multi-track CUE source and confirm recoverable seeks do not mark tracks as failed.
- Trigger rapid track transitions and confirm late errors remain attached to their originating tracks.
- Queue an unopenable multi-track source followed by a valid track.
- Confirm Cog skips the failed source without probing every logical track and begins playing the valid fallback.
- Confirm failed intermediate tracks are not briefly presented as the current stream.